### PR TITLE
Do not return Uuid by value

### DIFF
--- a/include/vrv/object.h
+++ b/include/vrv/object.h
@@ -221,7 +221,7 @@ public:
      */
     virtual void CloneReset();
 
-    std::string GetUuid() const { return m_uuid; }
+    const std::string& GetUuid() const { return m_uuid; }
     void SetUuid(std::string uuid);
     void SwapUuid(Object *other);
     void ResetUuid();


### PR DESCRIPTION
- GetUuid() is called a lot of times in TimeSpanningInterface. This scales with amount of time spanning elements in the file and ends up being a big perfomance bottleneck. Returning by const reference allows to get rid of ctor and dtor calls for std::string and time related to that.