### PR TITLE
Update logic of detecting overlapping augmentation dots

### DIFF
--- a/include/vrv/note.h
+++ b/include/vrv/note.h
@@ -279,6 +279,12 @@ private:
 
     void UpdateFromTransPitch(const TransPitch &tp);
 
+    /**
+     * Return whether dots are overlapping with flag. Take into account flag height, its position as well
+     * as position of the note and position of the dots
+     */
+    bool IsDotOverlappingWithFlag(Doc *doc, const int staffSize, bool isDotShifted);
+
 public:
     //
 private:


### PR DESCRIPTION
- changed how overlapping dots were found. Instead of using dot location, use Y cooridnates and height of the flag symbol to find whether elements are close enough to overlap.