### PR TITLE
Triggering build of Verovio Editor on enote-stage branch changes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ Release/
 
 # Fonts
 fonts/tmp/
+/.idea/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,6 @@ build-toolkit:
     - source emsdk_env.sh
     - cd ../emscripten
     - ./buildToolkit -c -H -M
-    - echo "//Testing inside verovio toolkit" >> build/verovio-toolkit.js
   artifacts:
     paths:
       - emscripten/build/verovio-toolkit.js*
@@ -50,7 +49,7 @@ bridge:
   stage: deploy-editor
   only:
     refs:
-      - ci-deployment-verovio-editor
+      - enote-stage
   needs:
     - build-toolkit
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,54 @@
 ---
 stages:
+  - build
+  - build-toolkit
+  - build-viewer
+  - deploy-viewer
   - deploy-editor
 
 variables:
   EMSCRIPTEN_REPOSITORY: "https://github.com/emscripten-core/emsdk.git"
   EMSCRIPTEN_DIRECTORY: "emsdk"
 
+.build-template:
+  stage: build
+  script:
+    - cd tools
+    - cmake ../cmake -DNO_ABC_SUPPORT=ON -DNO_HUMDRUM_SUPPORT=ON -DNO_PAE_SUPPORT=ON
+    - make -j 10
+
+build-osx:
+  extends: .build-template
+  tags:
+    - macos
+
+build-linux:
+  extends: .build-template
+  image:
+    name: rikorose/gcc-cmake
+    entrypoint: [""]
+
+build-toolkit:
+  stage: build-toolkit
+  image:
+    name: rikorose/gcc-cmake
+    entrypoint: [""]
+  script:
+    - git clone $EMSCRIPTEN_REPOSITORY $EMSCRIPTEN_DIRECTORY
+    - cd $EMSCRIPTEN_DIRECTORY
+    - ./emsdk install latest
+    - ./emsdk activate latest
+    - source emsdk_env.sh
+    - cd ../emscripten
+    - ./buildToolkit -c -H -M
+  artifacts:
+    paths:
+      - emscripten/build/verovio-toolkit.js*
+
 bridge:
   stage: deploy-editor
+  dependencies:
+    - build-toolkit
   trigger:
     project: Verovio/verovio-humdrum-viewer
     branch: enote-develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ bridge:
   stage: deploy-editor
   only:
     refs:
-      - enote-stage
+      - ci-deployment-verovio-editor
   needs:
     - build-toolkit
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ build-toolkit:
 
 bridge:
   stage: deploy-editor
-  dependencies:
+  needs:
     - build-toolkit
   trigger:
     project: Verovio/verovio-humdrum-viewer

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ build-toolkit:
     - source emsdk_env.sh
     - cd ../emscripten
     - ./buildToolkit -c -H -M
+    - echo "//Testing inside verovio toolkit" >> build/verovio-toolkit.js
   artifacts:
     paths:
       - emscripten/build/verovio-toolkit.js*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   - build-toolkit
   - build-viewer
   - deploy-viewer
+  - deploy-editor
 
 variables:
   EMSCRIPTEN_REPOSITORY: "https://github.com/emscripten-core/emsdk.git"
@@ -45,7 +46,7 @@ build-toolkit:
       - emscripten/build/verovio-toolkit.js*
 
 bridge:
-  stage: deploy
+  stage: deploy-editor
   trigger:
     project: verovio/verovio-humdrum-viewer
     branch: ci-deployment-verovio-editor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,49 +1,10 @@
 ---
 stages:
-#  - build
-#  - build-toolkit
-#  - build-viewer
-#  - deploy-viewer
   - deploy-editor
 
 variables:
   EMSCRIPTEN_REPOSITORY: "https://github.com/emscripten-core/emsdk.git"
   EMSCRIPTEN_DIRECTORY: "emsdk"
-
-.build-template:
-  stage: build
-  script:
-    - cd tools
-    - cmake ../cmake -DNO_ABC_SUPPORT=ON -DNO_HUMDRUM_SUPPORT=ON -DNO_PAE_SUPPORT=ON
-    - make -j 10
-
-build-osx:
-  extends: .build-template
-  tags:
-    - macos
-
-build-linux:
-  extends: .build-template
-  image:
-    name: rikorose/gcc-cmake
-    entrypoint: [""]
-
-build-toolkit:
-  stage: build-toolkit
-  image:
-    name: rikorose/gcc-cmake
-    entrypoint: [""]
-  script:
-    - git clone $EMSCRIPTEN_REPOSITORY $EMSCRIPTEN_DIRECTORY
-    - cd $EMSCRIPTEN_DIRECTORY
-    - ./emsdk install latest
-    - ./emsdk activate latest
-    - source emsdk_env.sh
-    - cd ../emscripten
-    - ./buildToolkit -c -H -M
-  artifacts:
-    paths:
-      - emscripten/build/verovio-toolkit.js*
 
 bridge:
   stage: deploy-editor

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ variables:
 bridge:
   stage: deploy-editor
   trigger:
-    project: https://gitlab.gitlab.enote.com/verovio/verovio-humdrum-viewer
+    project: Verovio/verovio-humdrum-viewer
     branch: enote-develop
     strategy: depend
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,3 +43,10 @@ build-toolkit:
   artifacts:
     paths:
       - emscripten/build/verovio-toolkit.js*
+
+bridge:
+  stage: deploy
+  trigger:
+    project: verovio/verovio-humdrum-viewer
+    branch: ci-deployment-verovio-editor
+    strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,9 @@ build-toolkit:
 
 bridge:
   stage: deploy-editor
+  only:
+    refs:
+      - enote-stage
   needs:
     - build-toolkit
   trigger:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,5 +10,6 @@ bridge:
   stage: deploy-editor
   trigger:
     project: https://gitlab.gitlab.enote.com/verovio/verovio-humdrum-viewer
-    branch: ci-deployment-verovio-editor
+    branch: enote-develop
     strategy: depend
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,9 @@
 ---
 stages:
-  - build
-  - build-toolkit
-  - build-viewer
-  - deploy-viewer
+#  - build
+#  - build-toolkit
+#  - build-viewer
+#  - deploy-viewer
   - deploy-editor
 
 variables:
@@ -48,6 +48,6 @@ build-toolkit:
 bridge:
   stage: deploy-editor
   trigger:
-    project: verovio/verovio-humdrum-viewer
+    project: https://gitlab.gitlab.enote.com/verovio/verovio-humdrum-viewer
     branch: ci-deployment-verovio-editor
     strategy: depend


### PR DESCRIPTION
This PR adds a pipeline dependency between the Verovio project and the Verovio Editor projects, that whenever changes are pushed to the `enote-stage` branch, a build of the Verovio Editor will be triggered. 

Ticket: https://enotemusic.atlassian.net/browse/AD-1039?atlOrigin=eyJpIjoiZmU5MDRiMTBlNWM4NDhjYTg2YjU5NTVjZTlkNDQ0ZmYiLCJwIjoiaiJ9