### PR TITLE
Adding Python virtual environment and PyCharm directory to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ Release/
 
 # Fonts
 fonts/tmp/
+/venv/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,11 @@ Release/
 
 # Fonts
 fonts/tmp/
+
+# Python 
 /venv/
 .idea/
+/dist/
+CMakeFiles/
+CMakeCache.txt
+/bindings/python/verovio_wrap.cxx


### PR DESCRIPTION
This PR adds two directories to the gitignore file: 

- venv (typically used for virtual python executable)
- .idea (PyCharm / IntelliJ IDE directory)
